### PR TITLE
Fix repeated requests on previous streams chat

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function saveData(data) {
     fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
 }
 
-let { lastTimestamp } = loadData();
+let { lastTimestamp } = loadData(); // Meng-load data terbaru (Ignoring last chat before stream)
 
 async function fetchLiveChatMessages() {
     try {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import axios from "axios";
 import { google } from "googleapis";
+import fs from "fs";
 
 const API_KEY = process.env.YT_API_KEY;
 const OSU_API_KEY = process.env.OSU_API_KEY;
@@ -8,18 +9,36 @@ const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK;
 const LIVE_CHAT_ID = process.env.YT_LIVE_CHAT_ID;
 const youtube = google.youtube({ version: "v3", auth: API_KEY });
 
-const processedMessages = new Set(); // Menyimpan ID pesan yang sudah diproses
+const DATA_FILE = "chatData.json";
+
+function loadData() {
+    if (fs.existsSync(DATA_FILE)) {
+        return JSON.parse(fs.readFileSync(DATA_FILE, "utf8"));
+    }
+    return { lastTimestamp: null };
+}
+
+function saveData(data) {
+    fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+let { lastTimestamp } = loadData();
 
 async function fetchLiveChatMessages() {
     try {
         const res = await youtube.liveChatMessages.list({
             liveChatId: LIVE_CHAT_ID,
-            part: "snippet,authorDetails"
+            part: "snippet,authorDetails",
         });
 
+        if (!res.data.items || res.data.items.length === 0) return;
+
+        let newLastTimestamp = lastTimestamp; // Update waktu ke yang terbaru
+
         for (const message of res.data.items) {
-            const messageId = message.id;
-            if (processedMessages.has(messageId)) continue; // Lewati jika sudah diproses
+            const messageTimestamp = new Date(message.snippet.publishedAt).getTime();
+
+            if (lastTimestamp && messageTimestamp <= lastTimestamp) continue; // Mengabaikan Chat Lama (Agar tidak looping)
 
             const text = message.snippet.displayMessage;
             const username = message.authorDetails.displayName;
@@ -27,10 +46,19 @@ async function fetchLiveChatMessages() {
             const match = text.match(/^!req (\d+)$/);
             if (match) {
                 const beatmapId = match[1];
-                processedMessages.add(messageId); // Tandai pesan sebagai sudah diproses
                 sendToDiscord(beatmapId, username);
             }
+
+            if (!newLastTimestamp || messageTimestamp > newLastTimestamp) {
+                newLastTimestamp = messageTimestamp;
+            }
         }
+
+        if (newLastTimestamp) {
+            lastTimestamp = newLastTimestamp;
+            saveData({ lastTimestamp });
+        }
+
     } catch (error) {
         console.error("Error fetching live chat:", error);
     }
@@ -44,12 +72,12 @@ async function sendToDiscord(beatmapId, username) {
 
         const beatmap = response.data[0];
         const embed = {
-            title: `${beatmap.artist} - ${beatmap.title} [${beatmap.version}]`,
+            title: `${beatmap.artist} - ${beatmap.title} [${beatmap.version}] (${parseFloat(beatmap.difficultyrating).toFixed(2)}★)`,
             url: `https://osu.ppy.sh/b/${beatmapId}`,
             color: 16711680,
             fields: [
                 { name: "Mapper", value: beatmap.creator, inline: true },
-                { name: "Star Rating", value: beatmap.difficultyrating, inline: true },
+                { name: "Star Rating", value: `${parseFloat(beatmap.difficultyrating).toFixed(2)}★`, inline: true },
                 { name: "BPM", value: beatmap.bpm, inline: true },
                 { name: "Requested by", value: username, inline: false }
             ],


### PR DESCRIPTION
So, previously when this bot was running, and there was a request on the previous stream, the old requests would send back into the discord webhook and would continue to spam until the last request.

I fixed it using the timestamp method which makes it only read the most recent messages (Current Chat), and not reading the old messages (Latest Stream Chat).